### PR TITLE
handle other chunk-store backends that don't return empty buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ KDB.prototype.queryStream = function (q, opts) {
 KDB.prototype._get = function (n, cb) {
   var self = this
   self.store.get(n, function (err, buf) {
+    if (err && err.notFound) return cb(null, undefined)
     if (err) return cb(err)
     if (buf.length === 0) return cb(null, undefined)
     var node = { type: buf[0], n: n }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/peermaps/kdb-tree-store#readme",
   "devDependencies": {
     "fd-chunk-store": "^2.0.0",
+    "memory-chunk-store": "^1.2.0",
     "tape": "^4.2.2"
   },
   "dependencies": {

--- a/test/one.js
+++ b/test/one.js
@@ -1,6 +1,7 @@
 var kdbtree = require('../')
 var test = require('tape')
 var fdstore = require('fd-chunk-store')
+var memstore = require('memory-chunk-store')
 var tmpdir = require('os').tmpdir()
 
 var path = require('path')
@@ -12,6 +13,22 @@ test('one point', function (t) {
     types: [ 'float32', 'float32', 'float32', 'uint32' ],
     size: 4096,
     store: fdstore(4096, file)
+  })
+  kdb.insert([1,2,3], 9999, function (err) {
+    t.ifError(err)
+    kdb.query([1,2,3], function (err, pts) {
+      t.ifError(err)
+      t.deepEqual(pts, [ { point: [1,2,3], value: 9999 } ])
+    })
+  })
+})
+
+test('one point: memory-chunk-store backend', function (t) {
+  t.plan(3)
+  var kdb = kdbtree({
+    types: [ 'float32', 'float32', 'float32', 'uint32' ],
+    size: 4096,
+    store: memstore(4096)
   })
   kdb.insert([1,2,3], 9999, function (err) {
     t.ifError(err)


### PR DESCRIPTION
`fd-chunk-store` returns an empty Buffer when a chunk isn't found -- something that isn't consistent with what other chunk stores do. Right now, kdb-tree-store expects this behaviour, causing problems for other chunk-store backends.

This adds a check for `err.notFound` being present on errors to let other chunk stores work with this module.

I have a pending PR with memory-chunk-store to add the `notFound` functionality: https://github.com/mafintosh/memory-chunk-store/pull/3 Hopefully this behaviour can be propagated across other chunk-stores too.