### PR TITLE
refactor & optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,9 +444,9 @@ KDB.prototype._splitPointNode = function (node, pivot, axis, cb) {
   }
 }
 
-KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
+KDB.prototype._splitRegionNode = function (range, pivot, axis, cb) {
   var self = this
-  var rrange = self._regionRange(node.node.regions)
+  var rrange = self._regionRange(range.node.regions)
   rrange[axis][0] = pivot
 
   var right = {
@@ -456,12 +456,12 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
       regions: []
     }
   }
-  var left = node
+  var left = range
 
   ;(function loop (i) {
-    if (i >= node.node.regions.length) return done()
+    if (i >= range.node.regions.length) return done()
 
-    var r = node.node.regions[i]
+    var r = range.node.regions[i]
     if (r.range[axis][1] <= pivot) {
       // already in the right place
       loop(i+1)

--- a/index.js
+++ b/index.js
@@ -396,7 +396,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
                     parents[regionEntry.node] = { node: n, index: 0 }
                     parents[rightRegion.node] = { node: n, index: 1 }
                     self._put(regionEntry.node, leftNode, done)
-                    self._put(n, root, done, true)
+                    self._put(n, root, done)
                     function done (err) {
                       if (err) cb(err)
                       else if (--pending === 0) _insert(n, 0)
@@ -406,7 +406,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
                     self._put(regionEntry.node, leftNode, function (err) {
                       if (err) cb(err)
                       else loop(parents[regionEntry.node])
-                    }, true)
+                    })
                   }
                 })
               })
@@ -513,7 +513,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
             rright.node = { type: REGION, regions: [ spr ] }
             rright.node.n = self._alloc()
             var pending = 2
-            self._put(rright.node.n, rright.node, done, true)
+            self._put(rright.node.n, rright.node, done)
             self._put(leftNode.n, leftNode, done)
             function done (err) {
               if (err) cb(err)

--- a/index.js
+++ b/index.js
@@ -330,12 +330,12 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
       self._put(self._alloc(), pts, function (err) {
         if (--pending === 0) f(err, node)
       })
-    } else insert(node.n, 0)
+    } else _insert(node.n, 0)
   })
 
   var parents = []
 
-  function insert (nodeIdx, depth) {
+  function _insert (nodeIdx, depth) {
     self._get(nodeIdx, function (err, node) {
       if (err) return cb(err)
       if (node.type === REGION) {
@@ -348,11 +348,11 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
             if (typeof r.node === 'number') {
               self._get(r.node, function (err, rnode) {
                 parents[rnode.n] = { node: node, index: i }
-                insert(rnode.n, depth+1)
+                _insert(rnode.n, depth+1)
               })
             } else {
               parents[r.node.n] = { node: node, index: i }
-              insert(r.node.n, depth+1)
+              _insert(r.node.n, depth+1)
             }
             return
           }
@@ -375,7 +375,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
         if (self._willOverflow(parents[node.n].node, 1)) {
           ;(function loop (p) {
             if (!self._willOverflow(p.node, 1)) {
-              return insert(p.node.n, depth+1)
+              return _insert(p.node.n, depth+1)
             }
             self._splitRegionNode(p.node, pivot, axis, function (err, right) {
               if (err) return cb(err)
@@ -394,7 +394,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
                 self._put(n, root, done)
                 function done (err) {
                   if (err) cb(err)
-                  else if (--pending === 0) insert(n, 0)
+                  else if (--pending === 0) _insert(n, 0)
                 }
               } else {
                 p.node.regions.push(right)
@@ -420,7 +420,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
             pnode.regions.push(rregion)
             self._put(pnode.n, pnode, function (err) {
               if (err) cb(err)
-              else insert(pnode.n, depth+1)
+              else _insert(pnode.n, depth+1)
             })
           })
         }

--- a/index.js
+++ b/index.js
@@ -97,13 +97,13 @@ KDB.prototype.queryStream = function (q, opts) {
 
 KDB.prototype._get = function (n, cb) {
   var self = this
+  if (self.cache[n]) return process.nextTick(cb, null, self.cache[n])
   self.store.get(n, function (err, buf) {
     if (err && err.notFound) return cb(null, undefined)
     if (err) return cb(err)
     if (buf.length === 0) return cb(null, undefined)
     var node = { type: buf[0], n: n }
     if (node.type === REGION) {
-      if (self.cache[n]) return cb(null, self.cache[n])
       node.regions = []
       var nregions = buf.readUInt16BE(1)
       var offset = 3
@@ -125,7 +125,6 @@ KDB.prototype._get = function (n, cb) {
       }
       cb(null, node)
     } else if (node.type === POINTS) {
-      if (self.cache[n]) return cb(null, self.cache[n])
       node.points = []
       var npoints = buf.readUInt16BE(1)
       var offset = 3

--- a/index.js
+++ b/index.js
@@ -372,7 +372,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
           if (!self._willOverflow(p.node, 1)) {
             return insert(p.node, depth+1)
           }
-          self._splitRegionNode(p, p.node, pivot, axis, function (err, right) {
+          self._splitRegionNode(p.node, pivot, axis, function (err, right) {
             if (err) return cb(err)
             if (p.node.n === 0 || self._willOverflow(p.node, 1)) {
               p.range = self._regionRange(p.node.regions)
@@ -448,7 +448,7 @@ KDB.prototype._splitPointNode = function (nodeIdx, pivot, axis, cb) {
   })
 }
 
-KDB.prototype._splitRegionNode = function (left, node, pivot, axis, cb) {
+KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   var self = this
   var rrange = self._regionRange(node.regions)
   rrange[axis][0] = pivot
@@ -490,7 +490,7 @@ KDB.prototype._splitRegionNode = function (left, node, pivot, axis, cb) {
             loop(i+1)
           })
         } else if (rnode.type === REGION) {
-          self._splitRegionNode(r, rnode, pivot, axis, function (err, spr) {
+          self._splitRegionNode(rnode, pivot, axis, function (err, spr) {
             if (err) return cb(err)
             rright.node = { type: REGION, regions: [ spr ] }
             rright.node.n = self._alloc()

--- a/index.js
+++ b/index.js
@@ -450,9 +450,9 @@ KDB.prototype._splitPointNode = function (nodeIdx, pivot, axis, cb) {
 
 KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   var self = this
+
   var rrange = self._regionRange(node.regions)
   rrange[axis][0] = pivot
-
   var right = {
     range: rrange,
     node: {
@@ -479,8 +479,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
       rright.range[axis][0] = pivot
       right.node.regions.push(rright)
 
-      var rleft = r
-      rleft.range[axis][1] = pivot
+      r.range[axis][1] = pivot
       self._get(r.node, function (err, rnode) {
         if (err) return cb(err)
         if (rnode.type === POINTS) {

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ KDB.prototype._put = function (n, node, cb, skipCache) {
   buf.writeUInt8(node.type, 0)
   node.n = n
   if (node.type === REGION) {
-    if (!skipCache) self.cache[n] = require('clone')(node)
+    if (!skipCache) self.cache[n] = node
     else self.cache[n] = null
     var len = node.regions.length
     buf.writeUInt16BE(len, 1)
@@ -465,8 +465,6 @@ KDB.prototype._splitPointNode = function (nodeIdx, pivot, axis, cb) {
 
 KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   var self = this
-
-  node = require('clone')(node)
 
   var rightNode = {
     type: REGION,

--- a/index.js
+++ b/index.js
@@ -415,13 +415,13 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
         } else {
           self._splitPointNode(node.n, pivot, axis, function (err, left, right) {
             if (err) return cb(err)
-            var pnode = parents[node.n].node
-            var pix = parents[node.n].index
+            var pnode = parents[left.n].node
+            var pix = parents[left.n].index
             var lrange = clone(pnode.regions[pix].range)
             var rrange = clone(pnode.regions[pix].range)
             lrange[axis][1] = pivot
             rrange[axis][0] = pivot
-            var lregion = { range: lrange, node: node.n }
+            var lregion = { range: lrange, node: left.n }
             var rregion = { range: rrange, node: right.n }
             pnode.regions[pix] = lregion
             pnode.regions.push(rregion)

--- a/index.js
+++ b/index.js
@@ -475,7 +475,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   rrange[axis][0] = pivot
   var rightRegion = {
     range: rrange,
-    node: rightNode
+    node: undefined
   }
 
   ;(function loop (i) {
@@ -525,6 +525,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
 
   function done () {
     rightNode.n = self._alloc()
+    rightRegion.node = rightNode.n
     self._put(rightNode.n, rightNode, function (err) {
       if (err) cb(err)
       else cb(null, rightRegion, node)

--- a/index.js
+++ b/index.js
@@ -463,9 +463,9 @@ KDB.prototype._splitRegionNode = function (range, pivot, axis, cb) {
   var left = range
 
   ;(function loop (i) {
-    if (i >= range.node.regions.length) return done()
+    if (i >= left.node.regions.length) return done()
 
-    var r = range.node.regions[i]
+    var r = left.node.regions[i]
     if (r.range[axis][1] <= pivot) {
       // already in the right place
       loop(i+1)

--- a/index.js
+++ b/index.js
@@ -466,14 +466,16 @@ KDB.prototype._splitPointNode = function (nodeIdx, pivot, axis, cb) {
 KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   var self = this
 
+  var rightNode = {
+    type: REGION,
+    regions: []
+  }
+
   var rrange = self._regionRange(node.regions)
   rrange[axis][0] = pivot
   var rightRegion = {
     range: rrange,
-    node: {
-      type: REGION,
-      regions: []
-    }
+    node: rightNode
   }
 
   ;(function loop (i) {
@@ -484,7 +486,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
       // already in the right place
       loop(i+1)
     } else if (r.range[axis][0] >= pivot) {
-      rightRegion.node.regions.push(r)
+      rightNode.regions.push(r)
       node.regions.splice(i, 1)
       loop(i)
     } else {
@@ -492,7 +494,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
         range: clone(r.range)
       }
       rright.range[axis][0] = pivot
-      rightRegion.node.regions.push(rright)
+      rightNode.regions.push(rright)
 
       r.range[axis][1] = pivot
       self._get(r.node, function (err, rnode) {
@@ -522,10 +524,10 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   })(0)
 
   function done () {
-    rightRegion.node.n = self._alloc()
-    self._put(rightRegion.node.n, rightRegion.node, function (err) {
+    rightNode.n = self._alloc()
+    self._put(rightNode.n, rightNode, function (err) {
       if (err) cb(err)
-      else cb(null, rightRegion, rightRegion.node, node)
+      else cb(null, rightRegion, rightNode, node)
     }, true)
   }
 }

--- a/index.js
+++ b/index.js
@@ -414,11 +414,9 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
           } else {
             self._splitPointNode(node.n, pivot, axis, function (err, left, right) {
               if (err) return cb(err)
-              console.log('1', parents[left.n])
               var pnodeidx = parents[left.n].node
               var pix = parents[left.n].index
               self._get(pnodeidx, function (err, pnode) {
-                console.log('pnode', pnode)
                 var lrange = clone(pnode.regions[pix].range)
                 var rrange = clone(pnode.regions[pix].range)
                 lrange[axis][1] = pivot
@@ -470,7 +468,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
 
   var rrange = self._regionRange(node.regions)
   rrange[axis][0] = pivot
-  var right = {
+  var rightRegion = {
     range: rrange,
     node: {
       type: REGION,
@@ -486,7 +484,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
       // already in the right place
       loop(i+1)
     } else if (r.range[axis][0] >= pivot) {
-      right.node.regions.push(r)
+      rightRegion.node.regions.push(r)
       node.regions.splice(i, 1)
       loop(i)
     } else {
@@ -494,7 +492,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
         range: clone(r.range)
       }
       rright.range[axis][0] = pivot
-      right.node.regions.push(rright)
+      rightRegion.node.regions.push(rright)
 
       r.range[axis][1] = pivot
       self._get(r.node, function (err, rnode) {
@@ -524,10 +522,10 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
   })(0)
 
   function done () {
-    right.node.n = self._alloc()
-    self._put(right.node.n, right.node, function (err) {
+    rightRegion.node.n = self._alloc()
+    self._put(rightRegion.node.n, rightRegion.node, function (err) {
       if (err) cb(err)
-      else cb(null, right, right.node, node)
+      else cb(null, rightRegion, rightRegion.node, node)
     }, true)
   }
 }

--- a/index.js
+++ b/index.js
@@ -382,7 +382,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
                 if (!self._willRegionOverflow(node, 1)) {
                   return _insert(regionEntry.node, depth+1)
                 }
-                self._splitRegionNode(node, pivot, axis, function (err, rightRegion, rightNode, leftNode) {
+                self._splitRegionNode(node, pivot, axis, function (err, rightRegion, leftNode) {
                   if (err) return cb(err)
                   if (regionEntry.node === 0 || self._willRegionOverflow(leftNode, 1)) {
                     regionEntry.range = self._regionRange(node.regions)
@@ -394,7 +394,7 @@ KDB.prototype.insert = queue(function (pt, value, cb) {
                     var n = regionEntry.node
                     regionEntry.node = self._alloc()
                     parents[regionEntry.node] = { node: n, index: 0 }
-                    parents[rightNode.n] = { node: n, index: 1 }
+                    parents[rightRegion.node] = { node: n, index: 1 }
                     self._put(regionEntry.node, node, done)
                     self._put(n, root, done, true)
                     function done (err) {
@@ -527,7 +527,7 @@ KDB.prototype._splitRegionNode = function (node, pivot, axis, cb) {
     rightNode.n = self._alloc()
     self._put(rightNode.n, rightNode, function (err) {
       if (err) cb(err)
-      else cb(null, rightRegion, rightNode, node)
+      else cb(null, rightRegion, node)
     }, true)
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/peermaps/kdb-tree-store#readme",
   "devDependencies": {
     "fd-chunk-store": "^2.0.0",
-    "memory-chunk-store": "^1.2.0",
+    "memory-chunk-store": "^1.3.0",
     "tape": "^4.2.2"
   },
   "dependencies": {


### PR DESCRIPTION
This PR applies a great deal of refactoring to the module. I originally tried to plug in a simple in-memory cache for parsed nodes when `_put()` is called, but there was a lot of complex semi-caching happening in the `insert` and `_split[Region|Point]Node` functions. The bulk of the work was refactoring those methods to act more like pure functions that don't modify in-memory state or mutate outside of themselves. Once that work was done, the rest fell into place.

Here are some numbers on speed comparing `master` to this branch:

## Benchmarks

### kdb-tree-store /w memory store

| |  insertion | full map query |
| ---- | ---- | ---- |
| before | 620ms | 15ms |
| after | 202ms |11ms |


| |  insertion | full map query |
| ---- | ---- | ---- |
| before|12555ms|77ms|
| after|2536ms|45ms|

## Digital Democracy datasets (all indexes)

| dataset | before | after |
| ---- | ---- | ---- |
| siekopai | 74043ms | 55199ms
| waorani | 72840ms | 56091ms

Addresses #1.